### PR TITLE
feat: remove lodash dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@element-plus/icons-vue": "^2.0.10",
     "@iconify-json/ep": "^1.1.8",
     "element-plus": "^2.2.18",
-    "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "vue": "^3.2.41",
     "vue-virtual-scroller": "2.0.0-beta.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ specifiers:
   '@vitejs/plugin-vue': ^3.1.2
   element-plus: ^2.2.18
   express: ^4.18.2
-  lodash: ^4.17.21
   lodash-es: ^4.17.21
   postcss: ^8.4.18
   rollup: ^3.2.3
@@ -26,7 +25,6 @@ dependencies:
   '@element-plus/icons-vue': 2.0.10_vue@3.2.41
   '@iconify-json/ep': 1.1.8
   element-plus: 2.2.18_vue@3.2.41
-  lodash: 4.17.21
   lodash-es: 4.17.21
   vue: 3.2.41
   vue-virtual-scroller: 2.0.0-beta.3_vue@3.2.41


### PR DESCRIPTION
由于 Rollup 的 TreeShaking 只能应用 esm 模块，又因为 `lodash` 是 cjs, 而 `lodash es` 为 esm 模块，所以 `lodash` 不再需要。